### PR TITLE
Fix Typo in URL

### DIFF
--- a/content/docs/getting-started/publishing.md
+++ b/content/docs/getting-started/publishing.md
@@ -31,7 +31,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:

--- a/content/docs/getting-started/reusing-messages.md
+++ b/content/docs/getting-started/reusing-messages.md
@@ -23,7 +23,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:
@@ -48,7 +48,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:
@@ -84,7 +84,7 @@ info:
   title: Hello world application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:

--- a/content/docs/getting-started/reusing-schemas.md
+++ b/content/docs/getting-started/reusing-schemas.md
@@ -21,7 +21,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:
@@ -67,7 +67,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:
@@ -110,7 +110,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:

--- a/content/docs/getting-started/security.md
+++ b/content/docs/getting-started/security.md
@@ -30,7 +30,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
     security:

--- a/content/docs/getting-started/servers.md
+++ b/content/docs/getting-started/servers.md
@@ -24,7 +24,7 @@ info:
   title: Hello world application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:

--- a/public/docs/getting-started/publishing/index.html
+++ b/public/docs/getting-started/publishing/index.html
@@ -399,7 +399,7 @@ info:
   title: Hello world publisher application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
 channels:

--- a/public/docs/getting-started/reusing-messages/index.html
+++ b/public/docs/getting-started/reusing-messages/index.html
@@ -385,7 +385,7 @@ info:
   title: Hello world publisher application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
 channels:
@@ -408,7 +408,7 @@ info:
   title: Hello world publisher application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
 channels:
@@ -450,7 +450,7 @@ info:
   title: Hello world application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
 channels:

--- a/public/docs/getting-started/reusing-schemas/index.html
+++ b/public/docs/getting-started/reusing-schemas/index.html
@@ -383,7 +383,7 @@ info:
   title: Hello world publisher application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
 channels:
@@ -431,7 +431,7 @@ info:
   title: Hello world publisher application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
 channels:
@@ -472,7 +472,7 @@ info:
   title: Hello world publisher application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
 channels:

--- a/public/docs/getting-started/security/index.html
+++ b/public/docs/getting-started/security/index.html
@@ -398,7 +398,7 @@ info:
   title: Hello world publisher application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
     security:

--- a/public/docs/getting-started/servers/index.html
+++ b/public/docs/getting-started/servers/index.html
@@ -389,7 +389,7 @@ info:
   title: Hello world application
   version: &#39;0.1.0&#39;
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is &#34;My Company&#34; broker.
 channels:


### PR DESCRIPTION
This commit fixes a typo in the URL in the examples.

"mycomapny" -> "mycompany"